### PR TITLE
Fixes compatibility with linux 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Apart from the aforementioned requirements, specific commands of Porta dev-tools
 ```shell
 export PORTA_DEV_TOOLS_PATH=/usr/local/porta-dev-tools
 git clone git@github.com:guicassolato/porta-dev-tools.git $PORTA_DEV_TOOLS_PATH
-echo "export PATH=$PORTA_DEV_TOOLS_PATH/bin:$PATH">>~/.zshrc
+echo "export PATH=$PORTA_DEV_TOOLS_PATH/bin:\$PATH">>~/.zshrc
 ```
 
 ### Settings/defaults

--- a/bin/porta
+++ b/bin/porta
@@ -38,6 +38,7 @@ module Porta
     apicast_access_token: 'apicastsecret',
     apicast_registry_url: 'https://apicast-staging.proda.3sca.net/policies',
     porta_local_provider_api: 'http://provider-admin.3scale.localhost:3000',
+    docker_internal_host: 'host.docker.internal',
     database_url: {
       mysql: 'mysql2://root:@127.0.0.1:3306/3scale_system_development',
       postgres: 'postgresql://postgres:@localhost/3scale_system_development',
@@ -493,11 +494,11 @@ module Porta
     end
 
     def run_porxy
-      system("docker run -d --name porxy --rm -p 3008:3008 #{options[:porxy_image]} >/dev/null && echo \"porxy\"")
+      system("docker run -d --name porxy --rm --add-host=host.docker.internal:host-gateway -p 3008:3008 #{options[:porxy_image]} >/dev/null && echo \"porxy\"")
     end
 
     def run_apicast
-      system("docker run -d --name apicast --rm -p 8080:8080 -e THREESCALE_PORTAL_ENDPOINT=\"http://#{options[:apicast_access_token]}@host.docker.internal:3008/master/api/proxy/configs\" -e THREESCALE_DEPLOYMENT_ENV=staging -e BACKEND_ENDPOINT_OVERRIDE=\"http://host.docker.internal:3001\" #{options[:apicast_image]} >/dev/null && echo \"apicast\"")
+      system("docker run -d --name apicast --rm -p 8080:8080 -e THREESCALE_PORTAL_ENDPOINT=\"http://#{options[:apicast_access_token]}@#{options[:docker_internal_host]}:3008/master/api/proxy/configs\" -e THREESCALE_DEPLOYMENT_ENV=staging -e BACKEND_ENDPOINT_OVERRIDE=\"http://#{options[:docker_internal_host]}:3001\" #{options[:apicast_image]} >/dev/null && echo \"apicast\"")
     end
 
     def run_sphinx

--- a/bin/porta
+++ b/bin/porta
@@ -406,6 +406,14 @@ module Porta
     def stdout_log?
       options[:stdout_log]
     end
+
+    def macos?
+      /darwin/ =~ RUBY_PLATFORM
+    end
+
+    def linux?
+      !macos?
+    end
   end
 
   class ServerCommand < CommandRunner
@@ -494,7 +502,7 @@ module Porta
     end
 
     def run_porxy
-      system("docker run -d --name porxy --rm --add-host=host.docker.internal:host-gateway -p 3008:3008 #{options[:porxy_image]} >/dev/null && echo \"porxy\"")
+      system("docker run -d --name porxy --rm #{'--add-host=host.docker.internal:host-gateway' if linux?} -p 3008:3008 #{options[:porxy_image]} >/dev/null && echo \"porxy\"")
     end
 
     def run_apicast

--- a/config/examples/settings.yml
+++ b/config/examples/settings.yml
@@ -17,3 +17,4 @@ settings:
   aws_bucket: '<aws-bucket>'
   aws_region: '<aws-region>'
   apicast_registry_url: 'https://apicast-staging.proda.3sca.net/policies'
+  docker_internal_host: 'host.docker.internal'

--- a/porxy/README.md
+++ b/porxy/README.md
@@ -19,6 +19,15 @@ address=/staging.apicast.dev/127.0.0.1
 
 The instructions were tested in Mac OS X with zsh shell. You may addapt to your own environment accordingly.
 
+#### Note that on linux you can't use `host.docker.internal` for internal communication.
+You should replace `host.docker.internal` with IP address of your docker instance.
+In the default configuration the IP address is `172.17.0.1`
+You can find the IP address with this command:
+```shell
+ip -4 addr show docker0 2>/dev/null | grep -Po 'inet \K[\d.]+'
+```
+This needs to be changed in the apisonator env file and `config/settings.yml` (`docker_internal_host: '172.17.0.1'`)
+
 ## Parameters
 
 Consider the following general parameters for the [Setup](#setup) and [Run](#run) sections below. Other parameters may be indicated specifically for each component.
@@ -68,6 +77,14 @@ CONFIG_REDIS_PROXY=host.docker.internal:6379/6\n\
 CONFIG_INTERNAL_API_USER=system_app\n\
 CONFIG_INTERNAL_API_PASSWORD=password\n\
 RACK_ENV=production" > <PATH_TO_APISONATOR_ENV_FILE>
+```
+
+### Env file for 3scale/porta
+Update an env file for 3scale/porta with following values:
+
+```shell
+CONFIG_INTERNAL_API_USER=system_app
+CONFIG_INTERNAL_API_PASSWORD=password
 ```
 
 ## Run


### PR DESCRIPTION
This PR fixes compatibility with Linux. It was tested on Arch Linux and it should hopefully work on any Linux distribution.

It needs to be tested with mac os since I am not sure if the `--add-host=host.docker.internal:host-gateway` option won't break anything.