### PR TITLE
Remove Porxy's entrypoint.sh

### DIFF
--- a/porxy/Dockerfile
+++ b/porxy/Dockerfile
@@ -5,9 +5,6 @@ COPY nginx.conf /etc/nginx/conf.d/nginx.conf
 
 RUN apt-get update && apt-get -y install iputils-ping
 
-COPY docker-entrypoint.sh /usr/local/bin/
-RUN ln -s /usr/local/bin/docker-entrypoint.sh /
-ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]
 
 EXPOSE 3008

--- a/porxy/docker-entrypoint.sh
+++ b/porxy/docker-entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exec "$@"


### PR DESCRIPTION
No longer needed since we started injecting the DNS config with docker `--add-host` option.