### PR TITLE
Disable IPv6 by default in pods

### DIFF
--- a/bin/porta
+++ b/bin/porta
@@ -378,7 +378,7 @@ module Porta
         hosts << "host.docker.internal"
         if `docker --version`.include?("podman")
           gw_ip = docker_internal_host
-          host_access = "--net slirp4netns:allow_host_loopback=true"
+          host_access = "--net slirp4netns:allow_host_loopback=true,enable_ipv6=false"
           if File.read("/etc/resolv.conf") =~ /nameserver\s+127\.0\.0\.1$/
             host_access += " --dns=#{gw_ip}"
           end


### PR DESCRIPTION
I'm experiencing this error:

`nginx: [emerg] invalid IPv6 address in resolver "[fe80::1%2]:53" in /tmp/lua_HPjysU:52`

Because of podman adding a IPv6 line to the container `/etc/resolv.conf`

```
nameserver 10.0.2.3
nameserver 192.168.100.1
nameserver fe80::1%2
```
This PR is to disable IPv6 in all containers while we figure out what's the problem