### PR TITLE
Fix keyword arguments for zync env vars

### DIFF
--- a/bin/porta
+++ b/bin/porta
@@ -844,13 +844,13 @@ module Porta
     end
 
     def run_zync_puma
-      in_zync(:system, 'PROMETHEUS_EXPORTER_PORT' => "#{options[:zync_prometheus_port]}") do
+      in_zync(:system, {'PROMETHEUS_EXPORTER_PORT' => "#{options[:zync_prometheus_port]}"}) do
         "bundle exec rails server -p 5000 &>#{zync_dir}/log/development.log & echo zync"
       end
     end
 
     def run_zync_que
-      in_zync(:system, 'PROMETHEUS_EXPORTER_PORT' => "#{options[:zync_prometheus_port]}") do
+      in_zync(:system, {'PROMETHEUS_EXPORTER_PORT' => "#{options[:zync_prometheus_port]}"}) do
         "bundle exec que &>#{zync_dir}/log/development.log & echo que"
       end
     end


### PR DESCRIPTION
The original code was working in Ruby 2.7, but not in Ruby 3.1 it fails with:

```
/path/to/porta-dev-tools/bin/porta:547:in `in_zync': unknown keyword: "PROMETHEUS_EXPORTER_PORT" (ArgumentError)
	from /path/to/porta-dev-tools/bin/porta:851:in `run_zync_puma'
	from /path/to/porta-dev-tools/bin/porta:847:in `run_zync'
	from /path/to/porta-dev-tools/bin/porta:825:in `run'
	from /path/to/porta-dev-tools/bin/porta:1103:in `<main>'
```

I am not quite sure, but probably this has something to do with the changes in how keyword and positional arguments are treated,as explained here: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

or maybe not... but this change seems to do the trick.