### PR TITLE
make setup work on modern OS OOB (hopefully)

### DIFF
--- a/bin/porta
+++ b/bin/porta
@@ -54,7 +54,7 @@ module Porta
     config_events_hook: 'http://master-account.3scale.localhost:3000/master/events/import',
     config_events_hook_shared_secret: 'supersecret',
     apicast_access_token: 'apicastsecret',
-    apicast_registry_url: 'https://apicast-staging.pro-saas.3sca.net/policies',
+    apicast_registry_url: 'https://policies.apicast.io/latest/policies.json',
     sidekiq_prometheus_port: "9395",
     zync_prometheus_port: "9396",
     zync_authentication_token: 'zync_token',
@@ -131,7 +131,10 @@ module Porta
 
     def run_apisonator_listener
       with_apisonator_env do |env_file|
-        system("#{container_tool} run -d --name apisonator --rm #{container_runtime_opts} -p 3001:3001 --env-file #{env_file} -it #{options[:apisonator_image]} 3scale_backend start -p 3001 -l /var/log/backend/3scale_backend.log >/dev/null && echo \"apisonator\"")
+        sync = (%w[CONFIG_REDIS_ASYNC=1 CONFIG_REDIS_ASYNC=true] & File.readlines(env_file, chomp: true)).empty?
+        server_param = "-s falcon" unless sync
+
+        system("#{container_tool} run -d --name apisonator --rm #{container_runtime_opts} -p 3001:3001 --env-file #{env_file} -it #{options[:apisonator_image]} 3scale_backend #{server_param} start --bind [::] -p 3001 >/dev/null && echo \"apisonator\"")
       end
     end
 
@@ -920,7 +923,14 @@ module Porta
     end
 
     def run_apicast
-      system("#{container_tool} run -d --name apicast --rm -p 8080:8080 #{container_runtime_opts} -e THREESCALE_PORTAL_ENDPOINT=\"http://#{options[:apicast_access_token]}@#{container_internal_ip}:3008/master/api/proxy/configs\" -e THREESCALE_DEPLOYMENT_ENV=staging -e BACKEND_ENDPOINT_OVERRIDE=\"http://#{container_internal_ip}:3001\" #{options[:apicast_image]} >/dev/null && echo \"apicast\"")
+      # we publish to 127.0.0.1 in particular because apicast only binds to
+      # IPv4 presently and current podman/pasta do not forward IPv6 connections
+      # to the exposed port. But still connection is created by kernel and
+      # immediately closed by pasta.
+      # The IP 127.0.0.1 can be removed when one of these happen:
+      #   * apicast binds to IPv6 (THREESCALE-11943)
+      #   * podman is fixed (https://github.com/containers/podman/issues/27125)
+      system("#{container_tool} run -d --name apicast --rm -p 127.0.0.1:8080:8080 #{container_runtime_opts} -e THREESCALE_PORTAL_ENDPOINT=\"http://#{options[:apicast_access_token]}@#{container_internal_ip}:3008/master/api/proxy/configs\" -e THREESCALE_DEPLOYMENT_ENV=staging -e APICAST_LOG_LEVEL=info -e BACKEND_ENDPOINT_OVERRIDE=\"http://#{container_internal_ip}:3001\" #{options[:apicast_image]} >/dev/null && echo \"apicast\"")
     end
 
     def run_sphinx

--- a/bin/porta
+++ b/bin/porta
@@ -674,7 +674,7 @@ module Porta
 
     def with_asdf(cmd)
       shell = ENV["SHELL"] || "sh"
-      "asdf env ruby #{shell} -c #{cmd.shellescape}"
+      "asdf env ruby -- #{shell} -c #{cmd.shellescape}"
     end
 
     def with_rbenv(cmd)

--- a/config/examples/settings.yml
+++ b/config/examples/settings.yml
@@ -20,4 +20,4 @@ settings:
   aws_secret_access_key: '<aws-secret-access-key>'
   aws_bucket: '<aws-bucket>'
   aws_region: '<aws-region>'
-  apicast_registry_url: 'https://apicast-staging.pro-saas.3sca.net/policies'
+  apicast_registry_url: 'https://policies.apicast.io/latest/policies.json'


### PR DESCRIPTION
These are changes to:
* update default policies URL that actually works
* fix how we start apicast so it doesn't confuse IPv4 fallback whenever `localhost` is used that resolves by default to IPv6 on Fedora. It also should not have any negative effects on IPv4 hosts
* fix how we start apisonator so that it binds to IPv6 and ends up accessible on both - IPv4 and IPv6 from the host perspective (depends on 3scale/apisonator#437)